### PR TITLE
pratom.h: 原子操作条件中增加loongarch64的判断。

### DIFF
--- a/pr/include/pratom.h
+++ b/pr/include/pratom.h
@@ -108,6 +108,7 @@ NSPR_API(PRInt32)   PR_AtomicAdd(PRInt32 *ptr, PRInt32 val);
            (defined(__arm__) && \
            defined(__GCC_HAVE_SYNC_COMPARE_AND_SWAP_4)) || \
            defined(__aarch64__) || defined(__alpha) || \
+	   defined(__loongarch64) || \
            (defined(__mips__) && \
            defined(__GCC_HAVE_SYNC_COMPARE_AND_SWAP_4)))))
 


### PR DESCRIPTION
pr/include/pratom.h里面增加"__loongarch64"的判断